### PR TITLE
Add catalog-info.yaml for console-ui integration of appeals application

### DIFF
--- a/src/applications/appeals/catalog-info.yaml
+++ b/src/applications/appeals/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    backstage.io/edit-url: https://github.com/mhaley37/vets-website/edit/main/src/applications/appeals/catalog_info.yaml
+    backstage.io/source-location: url:https://github.com/mhaley37/vets-website/tree/master/src/applications/appeals/
+    backstage.io/view-url: https://github.com/mhaley37/vets-website/blob/main/src/applications/appeals/catalog_info.yaml
+  description: The appeals application on vets-website
+  name: appeals
+  tags:
+  - spa
+  title: appeals
+spec:
+  lifecycle: production
+  owner: vsa-bam-1-frontend
+  subcomponentOf: vets-website
+  type: website


### PR DESCRIPTION
## Overview
This PR has been open by the @department-of-veterans-affairs/platform-pst-console-ui team to create a configuration file, [catalog-info.yaml](https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component), needed for integration into the [Platform Console](https://platform-console-ui-dev.vfs.va.gov).

## Steps to take
* Review the PR.  A default `catalog-info.yaml` has been created for this app. 
* Add any additional details if to the configuration as desired.  This [doc](https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component) details the different data that can be added
* If this application is not in use, this PR can be closed
* Reach out the the console-ui team with any questions.
